### PR TITLE
Remove the usage of java.security.acl which is entirely removed from …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk7
+  - openjdk17
 install:
   - sudo apt-get -y install nasm
 script: "./build.sh clean cd-x86-lite regression-tests"

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.jnode</groupId>
     <artifactId>jnode-fs</artifactId>
     <packaging>jar</packaging>
-    <version>0.3.2</version>
+    <version>0.3.3</version>
 
     <dependencies>
         <dependency>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
+            <version>31.1-jre</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -52,8 +52,8 @@
     </dependencies>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outuputEncoding>UTF-8</project.reporting.outuputEncoding>
         <slf4jVersion>1.7.32</slf4jVersion>

--- a/src/main/java/org/jnode/fs/spi/UnixFSAccessRights.java
+++ b/src/main/java/org/jnode/fs/spi/UnixFSAccessRights.java
@@ -21,7 +21,7 @@
 package org.jnode.fs.spi;
 
 import java.security.Principal;
-import java.security.acl.Group;
+
 import org.jnode.fs.FSAccessRights;
 import org.jnode.fs.FileSystem;
 
@@ -34,7 +34,7 @@ public class UnixFSAccessRights implements FSAccessRights {
     private final FileSystem<?> filesystem;
 
     private Principal owner;
-    private Group group;
+    private UnixFSGroup group;
 
     private final Rights ownerRights = new Rights(true, true, true);
     private final Rights groupRights = new Rights();

--- a/src/main/java/org/jnode/fs/spi/UnixFSGroup.java
+++ b/src/main/java/org/jnode/fs/spi/UnixFSGroup.java
@@ -1,13 +1,12 @@
 package org.jnode.fs.spi;
 
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-public class UnixFSGroup implements Group {
+public class UnixFSGroup {
 
     private final String name;
 
@@ -17,27 +16,22 @@ public class UnixFSGroup implements Group {
         this.name = name;
     }
 
-    @Override
     public boolean addMember(Principal user) {
         return members.add(user);
     }
 
-    @Override
     public boolean removeMember(Principal user) {
         return members.remove(user);
     }
 
-    @Override
     public boolean isMember(Principal member) {
         return members.contains(member);
     }
 
-    @Override
     public Enumeration<? extends Principal> members() {
         return Collections.enumeration(members);
     }
 
-    @Override
     public String getName() {
         return name;
     }


### PR DESCRIPTION
Remove the usage of java.security.acl which is entirely removed from jdk17.