### PR TITLE
Refactor, extract Flags classes out of superblock and inode class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.jnode</groupId>
     <artifactId>jnode-fs</artifactId>
     <packaging>jar</packaging>
-    <version>0.3.5-snapshot1</version>
+    <version>0.3.5-snapshot2</version>
 
     <dependencies>
         <dependency>

--- a/src/main/java/org/jnode/fs/xfs/Flags.java
+++ b/src/main/java/org/jnode/fs/xfs/Flags.java
@@ -1,0 +1,38 @@
+package org.jnode.fs.xfs;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * A bitmask of a set of flags.
+ */
+public interface Flags {
+    /**
+     * Check if a certain flag has been set in this flag number.
+     *
+     * @param value the certain flag.
+     * @return {@code true} if the flag has been set, {@code false} otherwise.
+     */
+    boolean isSet(long value);
+
+    /**
+     * Util class for getting the values out of a flag bitmask.
+     */
+    @AllArgsConstructor
+    class FlagUtil {
+        long flag;
+
+        public boolean isSet(long value) {
+            return (flag & value) == flag;
+        }
+
+        public static <F> List<F> fromValue(F[] values, long value) {
+            return Arrays.stream(values)
+                    .filter(f -> ((Flags) f).isSet(value))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/org/jnode/fs/xfs/README.md
+++ b/src/main/java/org/jnode/fs/xfs/README.md
@@ -4,9 +4,9 @@
 2. https://github.com/libyal/libfsxfs/blob/main/documentation/X%20File%20System%20(XFS).asciidoc
 
 ## Required information
-XFS file systems are divided into Aggregation groups(AG)
+XFS file systems are divided into Allocation groups(AG)
 
-Each agregation group contains serveral "main" elements of which only the Superblock(SB) of the first AG is useful for reading
+Each Allocation group contains several "main" elements of which only the Superblock(SB) of the first AG is useful for reading
 
 In order to partition data information is stored in Blocks(Blocks default size is 4096 Bytes)
 
@@ -30,12 +30,12 @@ it is recommended to compare the data structure Superblock to its PDF counterpar
 
 ### XFS Algorithms & Data Structures (PDF)
 
-This document contains the most recent spec as well as the v4 spec for every structure. 
+This document contains the most recent spec as well as the v4 and v5 spec for every structure. 
 B+tree Hash information can be ignored as it is only useful for optimized searches
 
 The information is recommended to be read in the following order:
 
-1. Aggregation groups
+1. Allocation groups
 2. SuperBlocks
 3. Data Extents
 4. INodes in the described order in the order presented in the PDF

--- a/src/main/java/org/jnode/fs/xfs/XfsFileSystem.java
+++ b/src/main/java/org/jnode/fs/xfs/XfsFileSystem.java
@@ -14,6 +14,7 @@ import org.jnode.fs.FileSystemType;
 import org.jnode.fs.spi.AbstractFileSystem;
 import org.jnode.fs.xfs.inode.INode;
 import org.jnode.fs.xfs.inode.INodeFactory;
+import org.jnode.fs.xfs.superblock.Superblock;
 
 /**
  * An XFS file system.

--- a/src/main/java/org/jnode/fs/xfs/XfsFileSystemType.java
+++ b/src/main/java/org/jnode/fs/xfs/XfsFileSystemType.java
@@ -1,14 +1,15 @@
 package org.jnode.fs.xfs;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
 import org.jnode.driver.Device;
 import org.jnode.driver.block.FSBlockDeviceAPI;
 import org.jnode.fs.BlockDeviceFileSystemType;
 import org.jnode.fs.FileSystemException;
+import org.jnode.fs.xfs.superblock.Superblock;
 import org.jnode.partitions.PartitionTableEntry;
 import org.jnode.util.BigEndian;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
 
 /**
  * The file system type for an XFS file system.

--- a/src/main/java/org/jnode/fs/xfs/extent/DataExtent.java
+++ b/src/main/java/org/jnode/fs/xfs/extent/DataExtent.java
@@ -1,8 +1,8 @@
 package org.jnode.fs.xfs.extent;
 
-import org.jnode.fs.xfs.Superblock;
 import org.jnode.fs.xfs.XfsFileSystem;
 import org.jnode.fs.xfs.XfsObject;
+import org.jnode.fs.xfs.superblock.Superblock;
 
 /**
  * A data extent ('xfs_bmbt_rec_t' packed, or 'xfs_bmbt_irec_t' unpacked).

--- a/src/main/java/org/jnode/fs/xfs/inode/FileMode.java
+++ b/src/main/java/org/jnode/fs/xfs/inode/FileMode.java
@@ -1,0 +1,60 @@
+package org.jnode.fs.xfs.inode;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * File modes.
+ * Specifies the mode access bits and type of file using the standard S_Ixxx values defined in stat.h.
+ *
+ * @see <a href="https://github.com/torvalds/linux/blob/master/include/uapi/linux/stat.h"> S_Ixxx in stat.h</a>
+ * @see <a href="https://en.wikibooks.org/wiki/C_Programming/POSIX_Reference/sys/stat.h#Member_constants">st_mode</a>
+ */
+public enum FileMode {
+    // FILE PERMISSIONS
+    OTHER_X(0x0007, 0x0001), // S_IXOTH
+    OTHER_W(0x0007, 0x0002), // S_IWOTH
+    OTHER_R(0x0007, 0x0004), // S_IROTH
+    GROUP_X(0x0038, 0x0008), // S_IXGRP
+    GROUP_W(0x0038, 0x0010), // S_IWGRP
+    GROUP_R(0x0038, 0x0020), // S_IRGRP
+    USER_X(0x01c0, 0x0040), // S_IXUSR
+    USER_W(0x01c0, 0x0080), // S_IWUSR
+    USER_R(0x01c0, 0x0100), // S_IRUSR
+    //TODO: Check mask
+//        STICKY_BIT(0xFFFF,0x0200), // S_ISVTX
+//        SET_GID(0xFFFF,0x0400), // S_ISGID
+//        SET_UID(0xFFFF,0x0800), // S_ISUID
+    // FILE TYPE
+    NAMED_PIPE(0xf000, 0x1000), // S_IFIFO
+    CHARACTER_DEVICE(0xf000, 0x2000), // S_IFCHR
+    DIRECTORY(0xf000, 0x4000), // S_IFDIR
+    BLOCK_DEVICE(0xf000, 0x6000), // S_IFBLK
+    FILE(0xf000, 0x8000), // S_IFREG
+    SYM_LINK(0xf000, 0xa000), // S_IFLNK
+    SOCKET(0xf000, 0xc000); // S_IFSOCK
+
+    /**
+     * The mask.
+     */
+    private final int mask;
+
+    /**
+     * The value.
+     */
+    private final int val;
+
+    FileMode(int mask, int val) {
+        this.mask = mask;
+        this.val = val;
+    }
+
+    public boolean isSet(int data) {
+        return (data & mask) == val;
+    }
+
+    public static List<FileMode> getModes(int data) {
+        return Arrays.stream(FileMode.values()).filter(mode -> mode.isSet(data)).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/jnode/fs/xfs/inode/Format.java
+++ b/src/main/java/org/jnode/fs/xfs/inode/Format.java
@@ -1,0 +1,63 @@
+package org.jnode.fs.xfs.inode;
+
+import java.util.Arrays;
+
+/**
+ * <p>inode format values.</p>
+ *
+ * <pre>
+ * typedef enum xfs_dinode_fmt {
+ *     XFS_DINODE_FMT_DEV,
+ *     XFS_DINODE_FMT_LOCAL,
+ *     XFS_DINODE_FMT_EXTENTS,
+ *     XFS_DINODE_FMT_BTREE,
+ *     XFS_DINODE_FMT_UUID,
+ *     XFS_DINODE_FMT_RMAP,
+ * } xfs_dinode_fmt_t;
+ * </pre>
+ */
+public enum Format {
+    /**
+     * Character and block devices.
+     */
+    DEV,
+
+    /**
+     * All metadata associated with the file is within the inode.
+     */
+    LOCAL,
+
+    /**
+     * The inode contains an array of extents to other filesystem blocks which contain
+     * the associated metadata or data.
+     */
+    EXTENTS,
+
+    /**
+     * The inode contains a B+tree root node which points to filesystem blocks containing
+     * the metadata or data.
+     */
+    BTREE,
+
+    /**
+     * Defined, but currently not used.
+     */
+    UUID,
+
+    /**
+     * A reverse-mapping B+tree is rooted in the fork.
+     */
+    RMAP,
+
+    /**
+     * Unknown
+     */
+    UNKNOWN;
+
+    public static Format fromValue(int value) {
+        return Arrays.stream(values())
+                .filter(fmt -> fmt.ordinal() == value)
+                .findFirst()
+                .orElse(UNKNOWN);
+    }
+}

--- a/src/main/java/org/jnode/fs/xfs/inode/INodeFactory.java
+++ b/src/main/java/org/jnode/fs/xfs/inode/INodeFactory.java
@@ -1,15 +1,14 @@
 package org.jnode.fs.xfs.inode;
 
+import java.io.IOException;
+
 import org.jnode.fs.xfs.XfsFileSystem;
 import org.jnode.fs.xfs.XfsObject;
-
-import java.io.IOException;
 
 /**
  * Creates inodes based on the version value read from the data.
  */
 public class INodeFactory {
-
     /**
      * Prevent instantiation.
      */
@@ -36,14 +35,13 @@ public class INodeFactory {
         }
 
         int version = obj.getUInt8(4);
-        if (version == 1) {
-            return new INode(inodeNumber, data, offset, fs);
-        }
-        else if (version == 2) {
-            return new INodeV2(inodeNumber, data, offset, fs);
-        }
-        else {
-            return new INodeV3(inodeNumber, data, offset, fs);
+        switch (version) {
+            case 1:
+                return new INode(inodeNumber, data, offset, fs);
+            case 2:
+                return new INodeV2(inodeNumber, data, offset, fs);
+            default:
+                return new INodeV3(inodeNumber, data, offset, fs);
         }
     }
 }

--- a/src/main/java/org/jnode/fs/xfs/inode/INodeV2.java
+++ b/src/main/java/org/jnode/fs/xfs/inode/INodeV2.java
@@ -1,7 +1,7 @@
 package org.jnode.fs.xfs.inode;
 
-import org.jnode.fs.xfs.Superblock;
 import org.jnode.fs.xfs.XfsFileSystem;
+import org.jnode.fs.xfs.superblock.AdditionalVersionFlags;
 
 /**
  * An XFS v2 inode ('xfs_dinode_core'). Structure definition in {@link INode}.
@@ -25,7 +25,7 @@ public class INodeV2 extends INode {
      */
     public int getProjectId() {
         int result = getUInt16(20);
-        if (Superblock.Features2.PROJID32BIT.isSet(fs.getSuperblock().getAdditionalFeatureFlags())) {
+        if (AdditionalVersionFlags.PROJID32BIT.isSet(fs.getSuperblock().getFeature2())) {
             result |= getUInt16(22) << 16;
         }
 

--- a/src/main/java/org/jnode/fs/xfs/inode/INodeV3.java
+++ b/src/main/java/org/jnode/fs/xfs/inode/INodeV3.java
@@ -1,17 +1,14 @@
 package org.jnode.fs.xfs.inode;
 
-import org.jnode.fs.xfs.XfsFileSystem;
-
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
+
+import org.jnode.fs.xfs.XfsFileSystem;
 
 /**
  * An XFS v3 inode ('xfs_dinode_core'). Structure definition in {@link INode}.
  */
 public class INodeV3 extends INodeV2 {
-
     /**
      * The offset to the v3 inode data.
      */
@@ -81,12 +78,12 @@ public class INodeV3 extends INodeV2 {
     }
 
     /**
-     * Gets the {@link List} of {@link Flag2} for the inode.
+     * Gets the {@link List} of {@link InodeV3Flags} for the inode.
      *
-     * @return the {@link List} of {@link Flag2} for the inode.
+     * @return the {@link List} of {@link InodeV3Flags} for the inode.
      */
-    public List<Flag2> getFlags2() {
-        return Flag2.fromValue(getRawFlags2());
+    public List<InodeV3Flags> getV3Flags() {
+        return InodeV3Flags.fromValue(getRawFlags2());
     }
 
     /**
@@ -146,48 +143,5 @@ public class INodeV3 extends INodeV2 {
     @Override
     public int getDataOffset() {
         return V3_DATA_OFFSET;
-    }
-
-    /**
-     * Extended flags associated with a v3 inode.
-     */
-    public enum Flag2 {
-
-        /**
-         * For a file, enable DAX to increase performance on
-         * persistent-memory storage. If set on a directory, files
-         * created in the directory will inherit this flag.
-         */
-        DAX(0x01),
-
-        /**
-         * This inode shares (or has shared) data blocks with another
-         * inode.
-         */
-        REFLINK(0x02),
-
-        /**
-         * For files, this is the extent size hint for copy on write
-         * operations; see di_cowextsize for details. For
-         * directories, the value in di_cowextsize will be copied
-         * to all newly created files and directories.
-         */
-        COWEXTSIZE(0x04);
-
-        private final long bitValue;
-
-        Flag2(int bitValue) {
-            this.bitValue = bitValue;
-        }
-
-        public boolean isSet(long value) {
-            return (bitValue & value) == bitValue;
-        }
-
-        static List<Flag2> fromValue(long value) {
-            return Arrays.stream(values())
-                    .filter(f -> f.isSet(value))
-                    .collect(Collectors.toList());
-        }
     }
 }

--- a/src/main/java/org/jnode/fs/xfs/inode/InodeFlags.java
+++ b/src/main/java/org/jnode/fs/xfs/inode/InodeFlags.java
@@ -1,0 +1,111 @@
+package org.jnode.fs.xfs.inode;
+
+import java.util.List;
+
+import org.jnode.fs.xfs.Flags;
+
+/**
+ * Specifies flags associated with the inode.
+ * Flags from the di_flags
+ * <p>inode flags.</p>
+ */
+public enum InodeFlags implements Flags {
+    /**
+     * The inode’s data is located on the real-time device.
+     */
+    REALTIME(0x01),
+
+    /**
+     * The inode’s extents have been preallocated.
+     */
+    PREALLOC(0x02),
+
+    /**
+     * Specifies the sb_rbmino uses the new real-time bitmap
+     * format.
+     */
+    NEWRTBM(0x04),
+
+    /**
+     * Specifies the inode cannot be modified.
+     */
+    IMMUTABLE(0x08),
+
+    /**
+     * The inode is in append only mode.
+     */
+    APPEND(0x10),
+
+    /**
+     * The inode is written synchronously.
+     */
+    SYNC(0x20),
+
+    /**
+     * The inode’s di_atime is not updated.
+     */
+    NOATIME(0x40),
+
+    /**
+     * Specifies the inode is to be ignored by xfsdump.
+     */
+    NODUMP(0x80),
+
+    /**
+     * For directory inodes, new inodes inherit the
+     * XFS_DIFLAG_REALTIME bit.
+     */
+    RTINHERIT(0x100),
+
+    /**
+     * For directory inodes, new inodes inherit the di_projid
+     * value.
+     */
+    PROJINHERIT(0x200),
+
+    /**
+     * For directory inodes, symlinks cannot be created.
+     */
+    NOSYMLINKS(0x400),
+
+    /**
+     * Specifies the extent size for real-time files or an extent size
+     * hint for regular files.
+     */
+    EXTSIZE(0x800),
+
+    /**
+     * For directory inodes, new inodes inherit the di_extsize
+     * value.
+     */
+    EXTSZINHERIT(0x1000),
+
+    /**
+     * Specifies the inode is to be ignored when defragmenting
+     * the filesystem.
+     */
+    NODEFRAG(0x2000),
+
+    /**
+     * Use the filestream allocator. The filestreams allocator
+     * allows a directory to reserve an entire allocation group for
+     * exclusive use by files created in that directory. Files in
+     * other directories cannot use AGs reserved by other
+     * directories
+     */
+    FILESTREAMS(0x4000);
+
+    private final FlagUtil flagUtil;
+
+    InodeFlags(long flags) {
+        this.flagUtil = new FlagUtil(flags);
+    }
+
+    public boolean isSet(long value) {
+        return flagUtil.isSet(value);
+    }
+
+    public static List<InodeFlags> fromValue(long value) {
+        return FlagUtil.fromValue(values(), value);
+    }
+}

--- a/src/main/java/org/jnode/fs/xfs/inode/InodeV3Flags.java
+++ b/src/main/java/org/jnode/fs/xfs/inode/InodeV3Flags.java
@@ -1,0 +1,46 @@
+package org.jnode.fs.xfs.inode;
+
+import java.util.List;
+
+import org.jnode.fs.xfs.Flags;
+
+/**
+ * Extended flags associated with a v3 inode.
+ * Flags from di_flags2.
+ */
+public enum InodeV3Flags implements Flags {
+    /**
+     * For a file, enable DAX to increase performance on
+     * persistent-memory storage. If set on a directory, files
+     * created in the directory will inherit this flag.
+     */
+    DAX(0x01),
+
+    /**
+     * This inode shares (or has shared) data blocks with another
+     * inode.
+     */
+    REFLINK(0x02),
+
+    /**
+     * For files, this is the extent size hint for copy on write
+     * operations; see di_cowextsize for details. For
+     * directories, the value in di_cowextsize will be copied
+     * to all newly created files and directories.
+     */
+    COWEXTSIZE(0x04);
+
+    private final FlagUtil flagUtil;
+
+    InodeV3Flags(long flags) {
+        this.flagUtil = new FlagUtil(flags);
+    }
+
+    public boolean isSet(long value) {
+        return flagUtil.isSet(value);
+    }
+
+    public static List<InodeV3Flags> fromValue(long value) {
+        return FlagUtil.fromValue(values(), value);
+    }
+}

--- a/src/main/java/org/jnode/fs/xfs/superblock/AdditionalVersionFlags.java
+++ b/src/main/java/org/jnode/fs/xfs/superblock/AdditionalVersionFlags.java
@@ -1,0 +1,73 @@
+package org.jnode.fs.xfs.superblock;
+
+import java.util.List;
+
+import org.jnode.fs.xfs.Flags;
+
+/**
+ * Flags from the sb_features2.
+ * Additional version flags if XFS_SB_VERSION_MOREBITSBIT is set in sb_versionnum. The currently
+ * defined additional features include flags in this class.
+ * AKA, Extended Version 4 Superblock flags.
+ */
+public enum AdditionalVersionFlags implements Flags {
+    /**
+     * Lazy global counters. Making a filesystem with this bit set can improve
+     * performance. The global free space and inode counts are only updated in
+     * the primary superblock when the filesystem is cleanly unmounted.
+     */
+    LAZYSBCOUNTBIT(0x01),
+
+    /**
+     * Extended attributes version 2. Making a filesystem with this optimises
+     * the inode layout of extended attributes. If this bit is set and the noattr2
+     * mount flag is not specified, the di_forkoff inode field will be dynamically
+     * adjusted.
+     */
+    ATTR2BIT(0x02),
+
+    /**
+     * Parent pointers. All inodes must have an extended attribute that points
+     * back to its parent node. The primary purpose for this information is in
+     * backup systems.
+     */
+    PARENTBIT(0x04),
+
+    /**
+     * 32-bit Project ID. Inodes can be associated with a project ID number,
+     * which can be used to enforce disk space usage quotas for a particular
+     * group of directories.This flag indicates that project IDs can be 32 bits
+     * in size.
+     */
+    PROJID32BIT(0x08),
+
+    /**
+     * Metadata checksumming. All metadata blocks have an extended header containing
+     * the block checksum, a copy of the metadata UUID, the log sequence number of the
+     * last update to prevent stale replays, and a back pointer to the owner of the
+     * block. This feature must be and can only be set of the lowest nibble of
+     * sb_versionnum is set to 5.
+     */
+    CRCBIT(0x10),
+
+    /**
+     * Directory file type. Each directory entry records the type of the inode to which
+     * the entry points. This speeds up directory iteration by removing the need to load
+     * every inode into memory.
+     */
+    FTYPE(0x20);
+
+    private final FlagUtil flagUtil;
+
+    AdditionalVersionFlags(int flags) {
+        this.flagUtil = new FlagUtil(flags);
+    }
+
+    public boolean isSet(long value) {
+        return flagUtil.isSet(value);
+    }
+
+    public static List<AdditionalVersionFlags> fromValue(long value) {
+        return FlagUtil.fromValue(values(), value);
+    }
+}

--- a/src/main/java/org/jnode/fs/xfs/superblock/QuotaFlags.java
+++ b/src/main/java/org/jnode/fs/xfs/superblock/QuotaFlags.java
@@ -1,0 +1,82 @@
+package org.jnode.fs.xfs.superblock;
+
+import java.util.List;
+
+import org.jnode.fs.xfs.Flags;
+
+/**
+ * Quota flags.
+ * Flags from the sb_qflags.
+ *
+ * @see <a href="https://github.com/torvalds/linux/blob/master/fs/xfs/libxfs/xfs_log_format.h#L857">xfs_log_format.h</a>
+ */
+public enum QuotaFlags implements Flags {
+    /**
+     * User quota accounting is enabled.
+     */
+    XFS_UQUOTA_ACCT(0x0001),
+
+    /**
+     * User quota limits enforced.
+     */
+    XFS_UQUOTA_ENFD(0x0002),
+
+    /**
+     * User quotas have been checked.
+     */
+    XFS_UQUOTA_CHKD(0x0004),
+
+    /**
+     * Project quota accounting is enabled.
+     */
+    XFS_PQUOTA_ACCT(0x0008),
+
+    /**
+     * Other (group/project) quotas are enforced.
+     */
+    XFS_OQUOTA_ENFD(0x0010),
+
+    /**
+     * Other (group/project) quotas have been checked.
+     */
+    XFS_OQUOTA_CHKD(0x0020),
+
+    /**
+     * Group quota accounting is enabled.
+     */
+    XFS_GQUOTA_ACCT(0x0040),
+
+    /**
+     * Group quotas are enforced.
+     */
+    XFS_GQUOTA_ENFD(0x0080),
+
+    /**
+     * Group quotas have been checked.
+     */
+    XFS_GQUOTA_CHKD(0x0100),
+
+    /**
+     * Project quotas are enforced.
+     */
+    XFS_PQUOTA_ENFD(0x0200),
+
+    /**
+     * Project quotas have been checked.
+     */
+    XFS_PQUOTA_CHKD(0x0400);
+
+    private final FlagUtil flagUtil;
+
+    QuotaFlags(int flags) {
+        this.flagUtil = new FlagUtil(flags);
+    }
+
+    public boolean isSet(long value) {
+        return flagUtil.isSet(value);
+    }
+
+    public static List<QuotaFlags> fromValue(int value) {
+        return FlagUtil.fromValue(values(), value);
+    }
+}

--- a/src/main/java/org/jnode/fs/xfs/superblock/VersionFlags.java
+++ b/src/main/java/org/jnode/fs/xfs/superblock/VersionFlags.java
@@ -1,0 +1,83 @@
+package org.jnode.fs.xfs.superblock;
+
+import java.util.List;
+
+import org.jnode.fs.xfs.Flags;
+
+/**
+ * The version flags in the version value sb_versionnum
+ * Filesystem version number. This is a bitmask specifying the features enabled when creating the filesystem.
+ * Any disk checking tools or drivers that do not recognize any set bits must not operate upon the filesystem.
+ * Most of the flags indicate features introduced over time. If the value of the lower nibble is >= 4, the higher bits
+ * indicate feature flags in this class.
+ */
+public enum VersionFlags implements Flags {
+    /**
+     * Set if any inode have extended attributes.
+     */
+    ATTRBIT(0x10),
+
+    /**
+     * Set if any inodes use 32-bit di_nlink values.
+     */
+    NLINKBIT(0x20),
+
+    /**
+     * Quotas are enabled on the filesystem. This also brings in the various quota fields in the superblock.
+     */
+    QUOTABIT(0x40),
+
+    /**
+     * Set if sb_inoalignmt is used.
+     */
+    ALIGNBIT(0x80),
+
+    /**
+     * Set if sb_unit and sb_width are used.
+     */
+    DALIGNBIT(0x100),
+
+    /**
+     * Set if sb_shared_vn is used.
+     */
+    SHAREDBIT(0x200),
+
+    /**
+     * Version 2 journaling logs are used.
+     */
+    LOGV2BIT(0x400),
+
+    /**
+     * Set if sb_sectsize is not 512.
+     */
+    SECTORBIT(0x800),
+
+    /**
+     * Unwritten extents are used. This is always set.
+     */
+    EXTFLGBIT(0x1000),
+
+    /**
+     * Version 2 directories are used. This is always set.
+     */
+    DIRV2BIT(0x2000),
+
+    /**
+     * Set if the sb_features2 field in the superblock contains more flags.
+     */
+    MOREBITSBIT(0x4000);
+
+    private final FlagUtil flagUtil;
+
+    VersionFlags(int flags) {
+        this.flagUtil = new FlagUtil(flags);
+    }
+
+    public boolean isSet(long value) {
+        return flagUtil.isSet(value);
+    }
+
+    public static List<VersionFlags> fromValue(int value) {
+        return FlagUtil.fromValue(values(), value);
+    }
+}


### PR DESCRIPTION
We'll add more flag enum classes soon, which may make the classes too big to maintain. 
Thus, before adding more flag classes, we extract the existing flags classes out of the superblock and inode class, to make them easier to extend.